### PR TITLE
Unindent dependencies in meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -103,4 +103,4 @@ galaxy_info:
   - system
   #- web
   #- platform
-  dependencies: []
+dependencies: []


### PR DESCRIPTION
The dependencies specified in meta/main.yml should not be a child of
`galaxy_info`. This causes issues when attempting to install this
role via `ansible-galaxy`:

```
$ ansible-galaxy install https://github.com/fupelaqu/ansible-docker-registry -p roles/
- executing: git clone https://github.com/fupelaqu/ansible-docker-registry ansible-docker-registry
- executing: git archive --prefix=ansible-docker-registry/ --output=/var/folders/xm/2nfw9x8x0qj6z91sd17v7qw00000gn/T/tmp5EuBSO.tar master
- extracting ansible-docker-registry to roles/ansible-docker-registry
- ansible-docker-registry was installed successfully
Traceback (most recent call last):
  File "/Users/dw/.envs/ansible/bin/ansible-galaxy", line 959, in <module>
    main()
  File "/Users/dw/.envs/ansible/bin/ansible-galaxy", line 953, in main
    fn(args, options, parser)
  File "/Users/dw/.envs/ansible/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'
```
